### PR TITLE
Upgrade ampersand-jsonapi-model

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "ampersand-jsonapi-collection": "^1.1.0",
-    "ampersand-jsonapi-model": "^1.2.0",
+    "ampersand-jsonapi-model": "^2.0.2",
     "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.5",
     "babel-loader": "^6.1.0",


### PR DESCRIPTION
I had to upgrade `ampersand-jsonapi-model` because the version we were using had bad dependencies and wasn’t listing `lodash.isObject` and as a result it wouldn’t `grunt build`.